### PR TITLE
Add CI job for iOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,22 @@ jobs:
           files: |
             numbat-*.apk
             numbat-*.aab
+
+  build-ios:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Build iOS library
+        working-directory: src-tauri
+        run: cargo build --target aarch64-apple-ios


### PR DESCRIPTION
Just does a build on `aarch64-apple-ios`. Doesn't properly invoke `cargo tauri` for now since that would require some setup for signing.